### PR TITLE
Refactor server to handle errors

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,5 @@
 import {get} from 'https';
-import express from 'express';
+// import express from 'express';
 import { 
   HeaderTransform, 
   FrameHeaderTransform, 
@@ -11,6 +11,7 @@ import {
   ColorTransform,
   CanvasTransform,
 } from './myTransforms.js';
+import { pipeline } from 'stream';
 
 const fixedLength = 4;
 function myTransform(url, _res, io) {
@@ -27,38 +28,63 @@ function myTransform(url, _res, io) {
     myObject.transparentColors = [];
     myObject.comments = [];
     myObject.localColorTables = [];
-    const frameStream = res  
-      .pipe(new HeaderTransform(myObject))
-      .pipe(new FrameHeaderTransform(myObject))
-      .pipe(new FrameImageTransform(myObject))
-      .pipe(new ColorTransform(myObject))
+    // const frameStream = res  
+    //   .pipe(new HeaderTransform(myObject))
+    //   .pipe(new FrameHeaderTransform(myObject))
+    //   .pipe(new FrameImageTransform(myObject))
+    //   .pipe(new ColorTransform(myObject))
+    //   .on('error', (err) => {
+    //     _res.status(500).send({ error: 'something blew up' })
+    //     _res.end();
 
-      frameStream
-        .pipe(new CanvasTransform(myObject))
-        .on('data', (data) => {
-          io.emit('colorFrame', data.toString());
-        });
+    //     return;
+    //   });
+    // _res.status(200);
+    const frameStream = pipeline(
+      res,  
+      new HeaderTransform(myObject),
+      new FrameHeaderTransform(myObject),
+      new FrameImageTransform(myObject),
+      new ColorTransform(myObject),
+      (err) => {
+        if (!err) {
+          return;
+        }
 
-      frameStream
-        .pipe(new GreyScaleTransform(myObject))
-        .pipe(new CompressionTransform(myObject))
-        .pipe(new AsciiTransform(myObject))
-        .pipe(new PulseTransform(myObject, frames))
-        .on('data', (data) => {
-          const buffer = Buffer.allocUnsafe(fixedLength);
-          buffer.writeInt32LE(data.length, 0);
-          _res.write(Buffer.concat([buffer, data]))
-        })
-        .on('finish', () => {
-          // need to extract the delays from the frames
-          const delays = frames
-            .map(({delay}) => delay);
+        console.log('err', err);
+        _res.status(500).json({ error: 'something blew up' })
+        _res.end();
+      }
+    );
 
-          const buffer = Buffer.allocUnsafe(fixedLength);
-          buffer.writeInt32LE(delays.length, 0);
-          _res.write(Buffer.concat([buffer, new Uint8Array(delays)]));
-          _res.end();
-        })
+    frameStream
+      .pipe(new CanvasTransform(myObject))
+      .on('data', (data) => {
+        io.emit('colorFrame', data.toString());
+      });
+
+    frameStream
+      .pipe(new GreyScaleTransform(myObject))
+      .pipe(new CompressionTransform(myObject))
+      .pipe(new AsciiTransform(myObject))
+      .pipe(new PulseTransform(myObject, frames))
+      .on('data', (data) => {
+        // const buffer = Buffer.allocUnsafe(fixedLength);
+        // buffer.writeInt32LE(data.length, 0);
+        // _res.write(Buffer.concat([buffer, data]))
+        io.emit('asciiFrame', data.toString());
+      })
+      .on('finish', () => {
+        // need to extract the delays from the frames
+        const delays = frames
+          .map(({delay}) => delay);
+
+        // const buffer = Buffer.allocUnsafe(fixedLength);
+        // buffer.writeInt32LE(delays.length, 0);
+        // _res.write(Buffer.concat([buffer, new Uint8Array(delays)]));
+        _res.status(200).send(delays)
+        _res.end();
+      })
   })
     .on('error', (err) => {
       if (err) {

--- a/app.js
+++ b/app.js
@@ -1,5 +1,4 @@
 import {get} from 'https';
-// import express from 'express';
 import { 
   HeaderTransform, 
   FrameHeaderTransform, 
@@ -13,7 +12,6 @@ import {
 } from './myTransforms.js';
 import { pipeline } from 'stream';
 
-const fixedLength = 4;
 function myTransform(url, _res, io) {
   get(url, (res) => {
     const frames = [];
@@ -28,18 +26,7 @@ function myTransform(url, _res, io) {
     myObject.transparentColors = [];
     myObject.comments = [];
     myObject.localColorTables = [];
-    // const frameStream = res  
-    //   .pipe(new HeaderTransform(myObject))
-    //   .pipe(new FrameHeaderTransform(myObject))
-    //   .pipe(new FrameImageTransform(myObject))
-    //   .pipe(new ColorTransform(myObject))
-    //   .on('error', (err) => {
-    //     _res.status(500).send({ error: 'something blew up' })
-    //     _res.end();
 
-    //     return;
-    //   });
-    // _res.status(200);
     const frameStream = pipeline(
       res,  
       new HeaderTransform(myObject),
@@ -52,7 +39,7 @@ function myTransform(url, _res, io) {
         }
 
         console.log('err', err);
-        _res.status(500).json({ error: 'something blew up' })
+        _res.status(500).send({ error: 'something blew up' })
         _res.end();
       }
     );
@@ -69,19 +56,12 @@ function myTransform(url, _res, io) {
       .pipe(new AsciiTransform(myObject))
       .pipe(new PulseTransform(myObject, frames))
       .on('data', (data) => {
-        // const buffer = Buffer.allocUnsafe(fixedLength);
-        // buffer.writeInt32LE(data.length, 0);
-        // _res.write(Buffer.concat([buffer, data]))
         io.emit('asciiFrame', data.toString());
       })
       .on('finish', () => {
         // need to extract the delays from the frames
         const delays = frames
           .map(({delay}) => delay);
-
-        // const buffer = Buffer.allocUnsafe(fixedLength);
-        // buffer.writeInt32LE(delays.length, 0);
-        // _res.write(Buffer.concat([buffer, new Uint8Array(delays)]));
         _res.status(200).send(delays)
         _res.end();
       })

--- a/index.html
+++ b/index.html
@@ -9,6 +9,8 @@
         white-space: pre-wrap;
         background: black;
         color: white;
+        display: flex;
+        justify-content: center;
       }
 
       .container {
@@ -18,8 +20,17 @@
         width: auto;
       }
 
-      #gifForm {
+      .form-container {
         display: flex;
+        flex-direction: column;
+      }
+
+      .field-container {
+        display: flex;
+      }
+
+      .error-message {
+        color: red;
       }
 
       #image {
@@ -34,9 +45,13 @@
       <p>The following parses a .gif file using node streams</p>
       <p>Each frame in the .gif is decompressed using the the LWZ algorithm. Every pixel is converted to greyscale and then assigned an ascii character.</p>
       <p>The frames are then rendered as an ascii representation of the original .gif. For comparison, the original colour frames are rendered also</p>
-      <p>The animations synced</p>
-      <form id="gifForm">
-        <input type="text" name="searchTerm" autocomplete="off" /><button name="send">Send</button>
+      <p>The animations are synced for comparison</p>
+      <form id="gifForm" class="form-container">
+        <div class="field-container">
+          <input type="text" name="searchTerm" autocomplete="off" /><button name="send">Send</button>
+        </div>
+        <!-- Add an error message that i can hide and show if the server returns an error -->
+        <span id="errorMessage" class="error-message" hidden="hidden">Something went wrong on the server. Try again.</span>
       </form>
       <div id="whereTheTextGoes" style="font-size: 0.5em; line-height: 0.66em"></div>
       <img id="image" alt="PNG Image">
@@ -47,6 +62,7 @@
       var textArea = document.getElementById('whereTheTextGoes');
       var imgElement = document.getElementById('image');
       var gifForm = document.getElementById('gifForm');
+      var errorMessage = document.getElementById('errorMessage');
       let timeoutId;
       let colorUrls = [];
       let frames = [];
@@ -74,9 +90,15 @@
 
       gifForm.addEventListener('submit', function(event) {
         event.preventDefault();
+
+        // Remove the error message if it exists
+        errorMessage.setAttribute('hidden', 'hidden')
         
+        // Stop the animation currently running
         stopAnimation(timeoutId);
+
         // disable the form so that it can't be changed while we're sending
+        // And reset the frame arrays to empty
         gifForm.elements.searchTerm.disabled = true;
         gifForm.elements.send.disabled = true;
         colorUrls = [];
@@ -84,13 +106,14 @@
         const formElement = event.target;
         const {value: searchTerm} = formElement.querySelector('input[name="searchTerm"]')
 
-        let prevBuffer;;
+        let prevBuffer;
         fetch(`/submit?searchTerm=${searchTerm}`, {
           method: 'GET',
         })
           .then((response) => {
             if (response.status !== 200) {
-              throw new Error('Something went wrong on api server!');
+              throw new Error('Something went wrong on the server!');
+              errorMessage.removeAttribute('hidden')
             }
 
             return response.json();
@@ -101,7 +124,6 @@
             gifForm.elements.send.disabled = false;
           })
           .catch((error) => {
-            console.error(error);
             // enable the form again
             gifForm.elements.searchTerm.disabled = false;
             gifForm.elements.send.disabled = false;

--- a/index.html
+++ b/index.html
@@ -49,6 +49,8 @@
       var gifForm = document.getElementById('gifForm');
       let timeoutId;
       let colorUrls = [];
+      let frames = [];
+
       function loopAnimation(frames, delays) {
         var i = 0;
         var loop = function() {
@@ -63,36 +65,48 @@
         loop();
       }
 
-      function stopAnimation(timeoutId, frames) {
+      function stopAnimation(timeoutId) {
         if (timeoutId) {
           clearTimeout(timeoutId);
         }
         timeoutId = undefined;
-        frames = [];
+        // frames = [];
       }
 
       gifForm.addEventListener('submit', function(event) {
         event.preventDefault();
-
+        
+        stopAnimation(timeoutId);
         // disable the form so that it can't be changed while we're sending
         gifForm.elements.searchTerm.disabled = true;
         gifForm.elements.send.disabled = true;
         colorUrls = [];
+        frames = [];
         const formElement = event.target;
         const {value: searchTerm} = formElement.querySelector('input[name="searchTerm"]')
 
-        let frames = [];
         let prevBuffer;;
         fetch(`/submit?searchTerm=${searchTerm}`, {
           method: 'GET',
         })
-          .then((response) => response.body)
-          .then((body) => {
+          .then((response) => {
+            if (response.status !== 200) {
+              throw new Error('Something went wrong on api server!');
+            }
+
+            return response.json();
+          })
+          .then((data) => {
+            loopAnimation(frames, data);
+            gifForm.elements.searchTerm.disabled = false;
+            gifForm.elements.send.disabled = false;
+            /*
+            console.log('body', body);
             const reader = body.getReader();
             const decoder = new TextDecoder();
 
             let count = 0;
-            stopAnimation(timeoutId, frames);
+            
 
             let previousTail = new Uint8Array([]);
             let incomingBufferSize = undefined;
@@ -143,12 +157,25 @@
 
             // Start reading the streamed data
             return readStream();
+            */
           })
+          .catch((error) => {
+            console.error(error);
+            // enable the form again
+            gifForm.elements.searchTerm.disabled = false;
+            gifForm.elements.send.disabled = false;
+          });
 
       })
 
+      socket.on('asciiFrame', (frame) => {
+        frames.push(frame);
+        textArea.innerHTML = frame;
+      });
+
       socket.on('colorFrame', (url) => {
         colorUrls.push(url);
+        imgElement.src = url;
       });
     </script>
   </body>

--- a/index.html
+++ b/index.html
@@ -70,7 +70,6 @@
           clearTimeout(timeoutId);
         }
         timeoutId = undefined;
-        // frames = [];
       }
 
       gifForm.addEventListener('submit', function(event) {
@@ -100,64 +99,6 @@
             loopAnimation(frames, data);
             gifForm.elements.searchTerm.disabled = false;
             gifForm.elements.send.disabled = false;
-            /*
-            console.log('body', body);
-            const reader = body.getReader();
-            const decoder = new TextDecoder();
-
-            let count = 0;
-            
-
-            let previousTail = new Uint8Array([]);
-            let incomingBufferSize = undefined;
-            let previousBufferSize = undefined;
-            function readStream() {
-              return reader.read().then(({ done, value }) => {
-                if (!done && !value) {
-                  return readStream();
-                }
-
-                if (done) {
-                  // enable the form again
-                  gifForm.elements.searchTerm.disabled = false;
-                  gifForm.elements.send.disabled = false;
-                  loopAnimation(frames, [...prevBuffer.subarray(4)]);
-                  return;
-                }
-
-                let buffer = new Uint8Array([...previousTail, ...value]);
-                if (buffer.length < 4) {
-                  previousTail = buffer;
-                  return readStream();
-                }
-
-                const lengthArray = buffer.slice(0, 4);
-                const incomingBufferSize = (lengthArray[3] << 24) | (lengthArray[2] << 16) | (lengthArray[1] << 8) | lengthArray[0];
-                if (buffer.length < incomingBufferSize + 4) {
-                  previousTail = buffer;
-                  return readStream();
-                }
-
-                previousTail = new Uint8Array([]);
-                if (prevBuffer) {
-                  const subArray = prevBuffer.subarray(4)
-                  const stringValue = decoder.decode(subArray).toString();
-                  textArea.innerHTML = stringValue;
-                  frames.push(stringValue);
-                  const url = colorUrls[frames.length - 1];
-                  if (url) {
-                    imgElement.src = url;
-                  }
-                }
-
-                prevBuffer = buffer;
-                return readStream();
-              });
-            }
-
-            // Start reading the streamed data
-            return readStream();
-            */
           })
           .catch((error) => {
             console.error(error);
@@ -165,7 +106,6 @@
             gifForm.elements.searchTerm.disabled = false;
             gifForm.elements.send.disabled = false;
           });
-
       })
 
       socket.on('asciiFrame', (frame) => {

--- a/index.js
+++ b/index.js
@@ -25,7 +25,12 @@ app.get('/submit', (req, res) => {
         // Something went wrong
       }
       const {data} = response.data;
-      // TODO test bad gif id jxzEhHBMmH7tm
+
+      /**
+       * TODO: Fix bad ids
+       * jxzEhHBMmH7tm
+       * 1GoHMc7DyBqQE
+       */
       const {id} = data[Math.floor(Math.random() * Math.min(data.length, limit))];
       console.log(id);
       myTransform(`https://media.giphy.com/media/${id}/giphy.gif`, res, io)

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 import express from 'express';
 import axios from 'axios';
 import 'dotenv/config'
-import bodyParser from 'body-parser';
 import path from 'path';
 import http from 'http';
 import {Server} from 'socket.io';
@@ -17,9 +16,7 @@ app.get('/', (req, res) => {
 });
 
 app.get('/submit', (req, res) => {
-  res.writeHead(200, {
-    'Content-Type': 'text/plain; charset=utf-8',
-  });
+  res.setHeader('Content-Type', 'text/plain; charset=utf-8'); 
   const limit = 25;
   const {searchTerm} = req.query;
   axios.get(`https://api.giphy.com/v1/gifs/search?api_key=${process.env.GIPHY_API_KEY}&q=${searchTerm}&limit=${limit}`)
@@ -27,9 +24,8 @@ app.get('/submit', (req, res) => {
       if (response.status !== 200) {
         // Something went wrong
       }
-
       const {data} = response.data;
-      console.log('data.length', data.length);
+      // TODO test bad gif id jxzEhHBMmH7tm
       const {id} = data[Math.floor(Math.random() * Math.min(data.length, limit))];
       console.log(id);
       myTransform(`https://media.giphy.com/media/${id}/giphy.gif`, res, io)


### PR DESCRIPTION
Errors on the server were not being handled correctly.
There were two main issues.
1. The response was using a stream to return the data in chunks. This was problematic if an error was thrown _after_ the stream had started
2. The response header was set with `writeHead` and therefor could not be reset

There were other issues, but these two seemed to be the root of most headaches.
There was no nice way to fix these issues separately. Instead I refactored the code to fix both. 
I replaced the response stream with a socket. Removed the `writeHead` and replaced by setting the status on an error or once the stream had finished.

Also included:
Code cleanup
New error message on the client