### PR TITLE
Set compression factor dynamically

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,8 +19,8 @@ function myTransform(url, _res, io) {
     myObject.delayTimes = []; 
     myObject.imagePositions = [];
     myObject.codeSizes = [];
-    myObject.widthCompression = 8;
-    myObject.heightCompression = 8;
+    // myObject.widthCompression = 8;
+    // myObject.heightCompression = 8;
     myObject.frames = [];
     myObject.canvasDataUrls = [];
     myObject.transparentColors = [];

--- a/app.js
+++ b/app.js
@@ -19,8 +19,6 @@ function myTransform(url, _res, io) {
     myObject.delayTimes = []; 
     myObject.imagePositions = [];
     myObject.codeSizes = [];
-    // myObject.widthCompression = 8;
-    // myObject.heightCompression = 8;
     myObject.frames = [];
     myObject.canvasDataUrls = [];
     myObject.transparentColors = [];

--- a/myTransforms.js
+++ b/myTransforms.js
@@ -25,22 +25,15 @@ export class HeaderTransform extends Transform {
     this.myObject.width = gifWidth;
     const gifHeight = chunk.readUInt16LE(8);
     this.myObject.height = gifHeight;
-    console.log('gifWidth', gifWidth);
 
-    // const {widthCompression, heightCompression} = this.myObject;
     const characterSize = 5.75;
     const viewWidth = 400;
     const compression = Math.floor(characterSize * gifWidth / viewWidth);
-    console.log('compression', compression);
-    // const compressedWidth = gifWidth % widthCompression === 0 ? gifWidth / widthCompression : Math.floor(gifWidth / widthCompression) + 1;
     const compressedWidth = (gifWidth - (gifWidth % compression)) / compression;
-    // This always returnin ~50 for some reason
-    console.log('compressedWidth', compressedWidth);
-    // const compressedHeight = gifHeight % heightCompression === 0 ? gifHeight / heightCompression : Math.floor(gifHeight / heightCompression) + 1;
     const compressedHeight = (gifHeight - (gifHeight % compression)) / compression;
+
     this.myObject.compressedWidth = compressedWidth;
     this.myObject.compressedHeight = compressedHeight;
-
     this.myObject.widthCompression = compression;
     this.myObject.heightCompression = compression;
 
@@ -498,7 +491,6 @@ export class CompressionTransform extends Transform {
 
   _transform(chunk, encoding, callback) {
     const {width: _gifWidth, height: _gifHeight, widthCompression, heightCompression} = this.gifObject;
-    // console.log('widthCompression', widthCompression);
     const pixelSize = widthCompression;
     const pixelSizeHeight = heightCompression;
     
@@ -531,8 +523,7 @@ export class AsciiTransform extends Transform {
   }
 
   _transform(chunk, encoding, callback) {
-    const {compressedWidth, widthCompression} = this.gifObject;
-    // console.log('compressedWidth', compressedWidth);
+    const {compressedWidth} = this.gifObject;
     const rows = [];
     let rowString = '';
     for (let i = 0; i < chunk.length; i++) {

--- a/myTransforms.js
+++ b/myTransforms.js
@@ -25,14 +25,24 @@ export class HeaderTransform extends Transform {
     this.myObject.width = gifWidth;
     const gifHeight = chunk.readUInt16LE(8);
     this.myObject.height = gifHeight;
+    console.log('gifWidth', gifWidth);
 
-    const {widthCompression, heightCompression} = this.myObject;
+    // const {widthCompression, heightCompression} = this.myObject;
+    const characterSize = 5.75;
+    const viewWidth = 400;
+    const compression = Math.floor(characterSize * gifWidth / viewWidth);
+    console.log('compression', compression);
     // const compressedWidth = gifWidth % widthCompression === 0 ? gifWidth / widthCompression : Math.floor(gifWidth / widthCompression) + 1;
-    const compressedWidth = (gifWidth - (gifWidth % widthCompression)) / widthCompression;
+    const compressedWidth = (gifWidth - (gifWidth % compression)) / compression;
+    // This always returnin ~50 for some reason
+    console.log('compressedWidth', compressedWidth);
     // const compressedHeight = gifHeight % heightCompression === 0 ? gifHeight / heightCompression : Math.floor(gifHeight / heightCompression) + 1;
-    const compressedHeight = (gifHeight - (gifHeight % heightCompression)) / heightCompression;
+    const compressedHeight = (gifHeight - (gifHeight % compression)) / compression;
     this.myObject.compressedWidth = compressedWidth;
     this.myObject.compressedHeight = compressedHeight;
+
+    this.myObject.widthCompression = compression;
+    this.myObject.heightCompression = compression;
 
     const gifField = chunk.readUInt8(10);
     const colorTableStart = 10;
@@ -488,6 +498,7 @@ export class CompressionTransform extends Transform {
 
   _transform(chunk, encoding, callback) {
     const {width: _gifWidth, height: _gifHeight, widthCompression, heightCompression} = this.gifObject;
+    // console.log('widthCompression', widthCompression);
     const pixelSize = widthCompression;
     const pixelSizeHeight = heightCompression;
     
@@ -521,6 +532,7 @@ export class AsciiTransform extends Transform {
 
   _transform(chunk, encoding, callback) {
     const {compressedWidth, widthCompression} = this.gifObject;
+    // console.log('compressedWidth', compressedWidth);
     const rows = [];
     let rowString = '';
     for (let i = 0; i < chunk.length; i++) {


### PR DESCRIPTION
Fixes #5 

Set the compression factor based on the pixel width so that the compressed width will always be approx 400px
Assuming the each character has a width ~5.75px and the view width is set to 400px then the compression ratio is gifWidth / viewWidth. 

Calculate the compression size as the compression ration * character width. From this get the rounded compressWidth (and compressedHeight).